### PR TITLE
WIP: Add timeout support for origins

### DIFF
--- a/examples/origin.rs
+++ b/examples/origin.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use axum::http::StatusCode;
 use axum::{routing::post, Router};
+use tokio::time::{sleep, Duration};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 #[tokio::main]
@@ -15,7 +16,8 @@ async fn main() -> Result<()> {
 
     let origin = Router::new()
         .route("/", post(success_handler))
-        .route("/failure", post(failure_handler));
+        .route("/failure", post(failure_handler))
+        .route("/timeout", post(timeout_handler));
 
     let addr = "0.0.0.0:8080";
     tracing::info!("origin listening on {}", addr);
@@ -35,4 +37,9 @@ async fn failure_handler() -> impl axum::response::IntoResponse {
         StatusCode::INTERNAL_SERVER_ERROR,
         "unexpected error".to_string(),
     )
+}
+
+async fn timeout_handler() -> impl axum::response::IntoResponse {
+    sleep(Duration::from_secs(6)).await;
+    "We shouldn't see this"
 }


### PR DESCRIPTION
First pass for https://github.com/hjr3/soldr/issues/3. Add timeout support for origins.


Should requests that timeout be added to the failed request list?

```
* Connected to localhost (127.0.0.1) port 3000 (#0)
> POST /timeout HTTP/1.1
> Host: example.wh.soldr.dev
> User-Agent: curl/7.81.0
> Accept: */*
> Content-Length: 0
> Content-Type: application/x-www-form-urlencoded
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 500 Internal Server Error
< content-type: text/plain; charset=utf-8
< content-length: 17
< date: Wed, 21 Jun 2023 00:11:32 GMT
< 
* Connection #0 to host localhost left intact
```

```
2023-06-21T00:08:33.442041Z DEBUG create_origin: soldr::mgmt: request payload = CreateOrigin { domain: "example.wh.soldr.dev", origin_uri: "http://localhost:8080" }
2023-06-21T00:08:33.442201Z TRACE create_origin: soldr::db: insert_origin
2023-06-21T00:08:33.443297Z DEBUG create_origin: soldr::mgmt: response = Origin { id: 1, domain: "example.wh.soldr.dev", origin_uri: "http://localhost:8080" }
2023-06-21T00:08:36.726696Z DEBUG ingest: soldr: HttpRequest { method: "POST", uri: "/timeout", headers: [("host", "example.wh.soldr.dev"), ("user-agent", "curl/7.81.0"), ("accept", "*/*"), ("content-length", "0"), ("content-type", "application/x-www-form-urlencoded")], body: Some([]) }
2023-06-21T00:08:36.726864Z TRACE ingest: soldr::db: insert_request
2023-06-21T00:08:36.728095Z DEBUG ingest: soldr::proxy: authority = example.wh.soldr.dev
2023-06-21T00:08:36.728243Z TRACE ingest: soldr::db: list_origins
2023-06-21T00:08:36.730846Z DEBUG soldr::proxy: origins = [Origin { id: 1, domain: "example.wh.soldr.dev", origin_uri: "http://localhost:8080" }]
2023-06-21T00:08:36.730932Z DEBUG soldr::proxy: example.wh.soldr.dev --> http://localhost:8080
2023-06-21T00:08:41.732184Z ERROR soldr::error: Error: deadline has elapsed
```
----

Alternatively I could handle the result from the timeout function, it seems to return `<Elapsed>()` if a timeout is reached. This might allow me to integrate the timeout error into the current failed request logic.

```
    let result = timeout(timeout_duration, client.request(new_req)).await;

    let response = match result {
        Ok(Ok(response)) => response,
        Ok(Err(e)) => {
            tracing::error!("Error making request: {}", e);
            return Ok(false);
        }
        Err(e) => {
            tracing::error!("Timeout making request: {}", e);
            return Ok(false);
        }
    };
```