### PR TITLE
fix: Clean up nested ingest span logging

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,6 @@ use axum::{routing::post, Router};
 use hyper::HeaderMap;
 use serde::Deserialize;
 use sqlx::sqlite::SqlitePool;
-use tracing::Level;
 
 use crate::db::{ensure_schema, insert_request, mark_complete, mark_error};
 use crate::error::AppError;
@@ -56,14 +55,12 @@ pub async fn app(config: Config) -> Result<(Router, Router, SqlitePool)> {
     Ok((router, mgmt_router, pool2))
 }
 
+#[tracing::instrument(level = "trace", "ingest", skip_all)]
 async fn handler(
     State(client): State<Client>,
     Extension(pool): Extension<SqlitePool>,
     req: Request<Body>,
 ) -> StdResult<impl IntoResponse, AppError> {
-    let span = tracing::span!(Level::TRACE, "ingest");
-    let _enter = span.enter();
-
     let method = req.method().to_string();
     let uri = req.uri().to_string();
     let headers = transform_headers(req.headers());


### PR DESCRIPTION
It seems `handler` trace was not closing scope properly when `router` was called async.

When sending a large number of requests to a successful endpoint I noticed that the span name was appending `ingest`. Notice the span names start appending `ingest`.

```
2023-07-01T03:12:14.875392Z TRACE ingest: soldr::db: insert_request
2023-07-01T03:12:14.875795Z DEBUG ingest: soldr::proxy: authority = example.wh.soldr.dev
2023-07-01T03:12:14.875827Z TRACE ingest: soldr::db: list_origins
2023-07-01T03:12:14.876075Z DEBUG soldr::proxy: origins = []
2023-07-01T03:12:14.876096Z TRACE soldr::proxy: no match found
2023-07-01T03:12:14.876121Z TRACE soldr::db: mark_complete
2023-07-01T03:12:14.884002Z DEBUG ingest:ingest: soldr: HttpRequest { method: "POST", uri: "/", headers: [("host", "example.wh.soldr.dev"), ("user-agent", "curl/7.81.0"), ("accept", "*/*"), ("content-length", "0"), ("content-type", "application/x-www-form-urlencoded")], body: Some([]) }
2023-07-01T03:12:14.884062Z TRACE ingest:ingest: soldr::db: insert_request
2023-07-01T03:12:14.884451Z DEBUG ingest:ingest: soldr::proxy: authority = example.wh.soldr.dev
2023-07-01T03:12:14.884477Z TRACE ingest:ingest: soldr::db: list_origins
2023-07-01T03:12:14.884635Z DEBUG soldr::proxy: origins = []
2023-07-01T03:12:14.884654Z TRACE soldr::proxy: no match found
2023-07-01T03:12:14.884671Z TRACE soldr::db: mark_complete
2023-07-01T03:12:14.892296Z DEBUG ingest:ingest:ingest: soldr: HttpRequest { method: "POST", uri: "/", headers: [("host", "example.wh.soldr.dev"), ("user-agent", "curl/7.81.0"), ("accept", "*/*"), ("content-length", "0"), ("content-type", "application/x-www-form-urlencoded")], body: Some([]) }

``` 

